### PR TITLE
init: do not clash with initramfs-framework package.

### DIFF
--- a/recipes-core/initrdscripts/readonly-rootfs-overlay-init-script.inc
+++ b/recipes-core/initrdscripts/readonly-rootfs-overlay-init-script.inc
@@ -7,12 +7,12 @@ SRC_URI = "file://init-readonly-rootfs-overlay-boot.sh"
 S = "${WORKDIR}"
 
 do_install() {
-        install -m 0755 ${WORKDIR}/init-readonly-rootfs-overlay-boot.sh ${D}/init
+        install -m 0755 ${WORKDIR}/init-readonly-rootfs-overlay-boot.sh ${D}/init-overlay
         install -d "${D}/media/rfs/ro"
         install -d "${D}/media/rfs/rw"
 }
 
-FILES_${PN} += " /init /media/rfs"
+FILES_${PN} += " /init-overlay /media/rfs"
 
 # Due to kernel dependency
 PACKAGE_ARCH = "${MACHINE_ARCH}"


### PR DESCRIPTION
Signed-off-by: Emmanuel Roullit <emmanuel.roullit@gmail.com>