### PR TITLE
initramfs: evict /init from initramfs framework

### DIFF
--- a/recipes-core/initrdscripts/initramfs-framework_%.bbappend
+++ b/recipes-core/initrdscripts/initramfs-framework_%.bbappend
@@ -1,0 +1,5 @@
+do_install_append () {
+    rm ${D}/init
+}
+
+FILES_${PN}_remove = "/init"


### PR DESCRIPTION
Signed-off-by: Emmanuel Roullit <emmanuel.roullit@gmail.com>